### PR TITLE
Support PINs longer than 4 digits

### DIFF
--- a/monosim-gtk/Src/Glade_Files/ChangePinStatusDialog.glade
+++ b/monosim-gtk/Src/Glade_Files/ChangePinStatusDialog.glade
@@ -124,7 +124,7 @@
                   <widget class="GtkEntry" id="TxtPin1">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
-                    <property name="max_length">4</property>
+                    <property name="max_length">8</property>
                     <property name="visibility">False</property>
                     <property name="invisible_char_set">True</property>
                     <property name="primary_icon_activatable">False</property>
@@ -141,7 +141,7 @@
                   <widget class="GtkEntry" id="TxtPin1check">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
-                    <property name="max_length">4</property>
+                    <property name="max_length">8</property>
                     <property name="visibility">False</property>
                     <property name="invisible_char_set">True</property>
                     <property name="primary_icon_activatable">False</property>

--- a/monosim-gtk/Src/Gui_Classes/ChangePinStatusDialogClass.cs
+++ b/monosim-gtk/Src/Gui_Classes/ChangePinStatusDialogClass.cs
@@ -73,7 +73,7 @@ namespace monosimgtk
 						                  GlobalObjUI.LMan.GetString("pinsimchk1"),
 						                  MessageType.Warning);
 				}
-				else if (pin1.Trim().Length != 4)
+				else if (pin1.Trim().Length > 8 || pin1.Trim().Length < 4)
 				{
 					// send warning message
 					MainClass.ShowMessage(mainWin, "ERROR", 
@@ -148,8 +148,9 @@ namespace monosimgtk
 			}
 			
 			// padd with 4 bytes to 0xFF
-			pinHexValue += new string('F', 8);
-			
+            if (pinValue.Length < 8) {
+                pinHexValue += new string('F', (8 - pinValue.Length)*2);
+            }
 			return pinHexValue;
 		}
 		


### PR DESCRIPTION
I had trouble unlocking my SIM card, as I had set  a PIN longer than 4 digits (I think the maximum is 8), so I patched the GUI to allow for longer PINs – and it works flawlessly. I only did this for the GTK version as the Qt one is a nightmare to build on Arch Linux.
